### PR TITLE
Fix GitHub Actions workflows and add CODEOWNERS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,8 @@ jobs:
     - name: Install dependencies
       run: yarn install --immutable
     
-    - name: TypeScript type check
-      run: yarn tsc:check || echo "Type check warnings - continuing build"
-    
-    - name: Generate TypeScript declarations
-      run: yarn tsc || echo "Declaration generation completed with warnings"
-    
     - name: Build package
-      run: yarn build:backstage
+      run: yarn build
     
     - name: Run tests
       run: yarn test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,14 +32,8 @@ jobs:
     - name: Install dependencies
       run: yarn install --immutable
     
-    - name: TypeScript type check
-      run: yarn tsc:check || echo "Type check warnings - continuing build"
-    
-    - name: Generate TypeScript declarations
-      run: yarn tsc || echo "Declaration generation completed with warnings"
-    
     - name: Build package
-      run: yarn build:backstage
+      run: yarn build
     
     - name: Run tests
       run: yarn test

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,18 @@
+# Global ownership
+* @mexl
+
+# Core plugin files
+/src/ @mexl
+/package.json @mexl
+/tsconfig.json @mexl
+
+# Documentation
+/README.md @mexl
+/CHANGELOG.md @mexl
+/docs/ @mexl
+
+# GitHub workflows and configuration
+/.github/ @mexl
+
+# Examples and templates
+/examples/ @mexl


### PR DESCRIPTION
## Summary
- Fix GitHub Actions workflows to use correct build scripts for frontend plugin
- Change from `yarn build:backstage` to `yarn build` (frontend plugin uses different scripts)
- Remove `yarn tsc:check` step (not available in frontend plugin)  
- Add CODEOWNERS file matching backend plugin

## Changes
- ✅ Updated CI workflow to use `yarn build` instead of `yarn build:backstage`
- ✅ Updated publish workflow to use `yarn build` instead of `yarn build:backstage`
- ✅ Removed TypeScript type check steps not available in frontend plugin
- ✅ Added CODEOWNERS file with @mexl ownership matching backend plugin

This fixes the workflow failures and aligns the frontend plugin with proper build scripts and repository governance.